### PR TITLE
Fix Warning On iOS 8

### DIFF
--- a/Pod/Classes/URBNEnvironmentPickerTableViewController.m
+++ b/Pod/Classes/URBNEnvironmentPickerTableViewController.m
@@ -17,10 +17,10 @@
     [super viewDidLoad];
 
     self.selectedEnvironment = [self currentEnvironment];
-    UIBarButtonItem *item = [[UIBarButtonItem alloc] initWithTitle:@"Cancel" style:UIBarButtonItemStyleBordered target:self action:@selector(cancel:)];
+    UIBarButtonItem *item = [[UIBarButtonItem alloc] initWithTitle:@"Cancel" style:UIBarButtonItemStylePlain target:self action:@selector(cancel:)];
 
     self.navigationItem.leftBarButtonItem = item;
-    item = [[UIBarButtonItem alloc] initWithTitle:@"Save" style:UIBarButtonItemStyleBordered target:self action:@selector(save:)];
+    item = [[UIBarButtonItem alloc] initWithTitle:@"Save" style:UIBarButtonItemStylePlain target:self action:@selector(save:)];
     self.navigationItem.rightBarButtonItem = item;
 }
 


### PR DESCRIPTION
Because we’re targeting >= iOS 7, we can just set this to “plain”

Warning:

```
Classes/URBNEnvironmentPickerTableViewController.m:20:84:
'UIBarButtonItemStyleBordered' is deprecated: first deprecated in iOS
8.0 - Use UIBarButtonItemStylePlain when minimum deployment target is
iOS7 or later
```
